### PR TITLE
Scaffold monorepo for sales call recorder platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.dist
+.next
+.DS_Store
+dist
+.env
+.env.local
+coverage
+.tmp
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# hi
+# Sales Call Recorder & AI Notes
+
+This repository contains the monorepo for a consent-first sales enablement platform. It provides a
+NestJS backend, a Next.js frontend, and documentation scaffolding aligned with the product
+requirements:
+
+* Record or upload sales calls and store them in S3-compatible storage.
+* Run transcription and summarization pipelines using queue workers (Whisper + rule-based NLP).
+* Capture consent events to comply with German call recording regulations.
+* Expose dashboards, KPIs, and exports for managers to coach their teams.
+
+## Getting started
+
+1. Install dependencies in each workspace:
+
+   ```bash
+   npm install --workspace=@sales-call/api
+   npm install --workspace=@sales-call/web
+   ```
+
+2. Run the development servers:
+
+   ```bash
+   npm run dev:api   # NestJS backend on http://localhost:8080
+   npm run dev:web   # Next.js frontend on http://localhost:3000
+   ```
+
+3. Explore the repository structure in [`docs/architecture.md`](docs/architecture.md) for the next
+   implementation steps.
+
+> **Note:** Database credentials, S3 settings, and other secrets are expected through environment
+> variables (`.env` files are intentionally excluded from version control).

--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@sales-call/api",
+  "version": "0.1.0",
+  "description": "NestJS backend for Sales Call Recorder",
+  "private": true,
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "nest build",
+    "start": "node dist/main",
+    "start:dev": "nest start --watch",
+    "lint": "eslint --ext .ts src"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/mapped-types": "^2.0.2",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "bcrypt": "^5.1.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
+    "pg": "^8.11.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.0",
+    "typeorm": "^0.3.17"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "@types/bcrypt": "^5.0.0",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.19",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "prettier": "^3.2.5",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get('health')
+  healthCheck() {
+    return this.appService.getHealth();
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { User } from './users/user.entity';
+import { Call } from './calls/call.entity';
+import { CallEvent } from './calls/call-event.entity';
+import { UsersModule } from './users/users.module';
+import { CallsModule } from './calls/calls.module';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRootAsync({
+      useFactory: () => ({
+        type: 'postgres',
+        url: process.env.DATABASE_URL,
+        autoLoadEntities: true,
+        synchronize: false
+      })
+    }),
+    TypeOrmModule.forFeature([User, Call, CallEvent]),
+    UsersModule,
+    CallsModule
+  ],
+  controllers: [AppController],
+  providers: [AppService]
+})
+export class AppModule {}

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHealth() {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString()
+    };
+  }
+}

--- a/apps/api/src/calls/call-event.entity.ts
+++ b/apps/api/src/calls/call-event.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn
+} from 'typeorm';
+import { Call } from './call.entity';
+
+export type CallEventType =
+  | 'consent_granted'
+  | 'consent_withdrawn'
+  | 'recording_started'
+  | 'recording_stopped'
+  | 'deleted'
+  | 'redacted'
+  | 'asr_done'
+  | 'nlp_done';
+
+@Entity({ name: 'call_events' })
+export class CallEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => Call, (call) => call.events, { nullable: false })
+  call!: Call;
+
+  @Column({ type: 'varchar', length: 64 })
+  eventType!: CallEventType;
+
+  @Column({ type: 'jsonb', nullable: true })
+  payload!: Record<string, unknown> | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+}

--- a/apps/api/src/calls/call.entity.ts
+++ b/apps/api/src/calls/call.entity.ts
@@ -1,0 +1,79 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { User } from '../users/user.entity';
+import { CallEvent } from './call-event.entity';
+
+export type ProcessingStatus = 'queued' | 'processing' | 'done' | 'error';
+
+@Entity({ name: 'calls' })
+export class Call {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => User, { nullable: false })
+  user!: User;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  company!: string | null;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  contactName!: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  startedAt!: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  endedAt!: Date | null;
+
+  @Column({ type: 'int', nullable: true })
+  durationSec!: number | null;
+
+  @Column({ type: 'boolean', default: false })
+  hasConsent!: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  meetingScheduled!: boolean;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  appointmentAt!: Date | null;
+
+  @Column({ type: 'text', nullable: true })
+  objections!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  outcomeNotes!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  audioUrl!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  transcriptText!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  summaryText!: string | null;
+
+  @Column({ type: 'varchar', length: 16, default: 'de-DE' })
+  language!: string;
+
+  @Column({ type: 'varchar', length: 16, default: 'queued' })
+  asrStatus!: ProcessingStatus;
+
+  @Column({ type: 'varchar', length: 16, default: 'queued' })
+  nlpStatus!: ProcessingStatus;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt!: Date;
+
+  @OneToMany(() => CallEvent, (event) => event.call)
+  events!: CallEvent[];
+}

--- a/apps/api/src/calls/calls.controller.ts
+++ b/apps/api/src/calls/calls.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post
+} from '@nestjs/common';
+import { CallsService } from './calls.service';
+import { CreateCallDto } from './dto/create-call.dto';
+import { UpdateCallDto } from './dto/update-call.dto';
+
+@Controller('calls')
+export class CallsController {
+  constructor(private readonly callsService: CallsService) {}
+
+  @Post()
+  create(@Body() dto: CreateCallDto) {
+    // TODO: replace with real authenticated user context
+    const userId = '00000000-0000-0000-0000-000000000000';
+    return this.callsService.create(userId, dto);
+  }
+
+  @Get()
+  findAll() {
+    const userId = '00000000-0000-0000-0000-000000000000';
+    return this.callsService.findAllForUser(userId);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.callsService.findOneOrFail(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateCallDto) {
+    return this.callsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.callsService.delete(id);
+  }
+}

--- a/apps/api/src/calls/calls.module.ts
+++ b/apps/api/src/calls/calls.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Call } from './call.entity';
+import { CallEvent } from './call-event.entity';
+import { CallsService } from './calls.service';
+import { CallsController } from './calls.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Call, CallEvent])],
+  providers: [CallsService],
+  controllers: [CallsController],
+  exports: [CallsService]
+})
+export class CallsModule {}

--- a/apps/api/src/calls/calls.service.ts
+++ b/apps/api/src/calls/calls.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Call } from './call.entity';
+import { CallEvent, CallEventType } from './call-event.entity';
+import { CreateCallDto } from './dto/create-call.dto';
+import { UpdateCallDto } from './dto/update-call.dto';
+
+@Injectable()
+export class CallsService {
+  constructor(
+    @InjectRepository(Call)
+    private readonly callRepository: Repository<Call>,
+    @InjectRepository(CallEvent)
+    private readonly callEventRepository: Repository<CallEvent>
+  ) {}
+
+  create(userId: string, dto: CreateCallDto) {
+    const call = this.callRepository.create({
+      ...dto,
+      user: { id: userId } as any,
+      asrStatus: 'queued',
+      nlpStatus: 'queued'
+    });
+    return this.callRepository.save(call);
+  }
+
+  findAllForUser(userId: string) {
+    return this.callRepository.find({
+      where: { user: { id: userId } },
+      relations: ['user']
+    });
+  }
+
+  async findOneOrFail(id: string) {
+    const call = await this.callRepository.findOne({
+      where: { id },
+      relations: ['user', 'events']
+    });
+    if (!call) {
+      throw new NotFoundException('Call not found');
+    }
+    return call;
+  }
+
+  async update(id: string, dto: UpdateCallDto) {
+    const call = await this.findOneOrFail(id);
+    Object.assign(call, dto);
+    return this.callRepository.save(call);
+  }
+
+  async delete(id: string) {
+    const call = await this.findOneOrFail(id);
+    await this.callRepository.remove(call);
+  }
+
+  async addEvent(callId: string, eventType: CallEventType, payload?: Record<string, unknown>) {
+    const call = await this.findOneOrFail(callId);
+    const event = this.callEventRepository.create({
+      call,
+      eventType,
+      payload: payload ?? null
+    });
+    return this.callEventRepository.save(event);
+  }
+}

--- a/apps/api/src/calls/dto/create-call.dto.ts
+++ b/apps/api/src/calls/dto/create-call.dto.ts
@@ -1,0 +1,27 @@
+import { IsBoolean, IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class CreateCallDto {
+  @IsOptional()
+  @IsString()
+  company?: string;
+
+  @IsOptional()
+  @IsString()
+  contactName?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  hasConsent?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  meetingScheduled?: boolean;
+
+  @IsOptional()
+  @IsString()
+  language?: string;
+
+  @IsOptional()
+  @IsUrl()
+  audioUrl?: string;
+}

--- a/apps/api/src/calls/dto/update-call.dto.ts
+++ b/apps/api/src/calls/dto/update-call.dto.ts
@@ -1,0 +1,21 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCallDto } from './create-call.dto';
+import { IsBoolean, IsISO8601, IsOptional, IsString } from 'class-validator';
+
+export class UpdateCallDto extends PartialType(CreateCallDto) {
+  @IsOptional()
+  @IsString()
+  outcomeNotes?: string;
+
+  @IsOptional()
+  @IsString()
+  objections?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  meetingScheduled?: boolean;
+
+  @IsOptional()
+  @IsISO8601()
+  appointmentAt?: string;
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,27 @@
+import { NestFactory } from '@nestjs/core';
+import { Logger, ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.enableCors();
+  app.setGlobalPrefix('api');
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true
+    })
+  );
+
+  const port = process.env.PORT || 8080;
+  await app.listen(port);
+  const logger = new Logger('Bootstrap');
+  logger.log(`API server listening on port ${port}`);
+}
+
+bootstrap().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('Failed to bootstrap API server', error);
+  process.exitCode = 1;
+});

--- a/apps/api/src/users/user.entity.ts
+++ b/apps/api/src/users/user.entity.ts
@@ -1,0 +1,33 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+
+export type UserRole = 'admin' | 'rep';
+
+@Entity({ name: 'users' })
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  name!: string;
+
+  @Column({ type: 'varchar', length: 255, unique: true })
+  email!: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  passwordHash!: string;
+
+  @Column({ type: 'varchar', length: 16, default: 'rep' })
+  role!: UserRole;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt!: Date;
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './user.entity';
+import { UsersService } from './users.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  providers: [UsersService],
+  exports: [UsersService]
+})
+export class UsersModule {}

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from './user.entity';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>
+  ) {}
+
+  findByEmail(email: string) {
+    return this.usersRepository.findOne({ where: { email } });
+  }
+
+  async create(user: Partial<User>) {
+    const entity = this.usersRepository.create(user);
+    return this.usersRepository.save(entity);
+  }
+}

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true
+  }
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 antialiased;
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Sales Call Recorder',
+  description: 'Capture, transcribe, and summarize sales calls with consent compliance.'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link';
+
+const navigation = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/calls/new', label: 'New Call' },
+  { href: '/settings', label: 'Settings' }
+];
+
+export default function HomePage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-12 px-6 py-16">
+      <section className="space-y-6">
+        <span className="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700">
+          Sales Call Recorder
+        </span>
+        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+          Record, transcribe, and understand every sales conversation.
+        </h1>
+        <p className="max-w-2xl text-lg text-slate-600">
+          A consent-first platform for German sales teams. Upload recordings or connect your dialer,
+          receive live transcripts, and let our AI extract the details that matter.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          {navigation.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      </section>
+      <section className="grid gap-6 md:grid-cols-2">
+        <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-xl font-semibold">Compliance built-in</h2>
+          <p className="mt-2 text-sm text-slate-600">
+            Consent workflows, withdrawal tracking, and audit logs are first-class citizens. Every
+            recording is easy to delete or redact when requested.
+          </p>
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-xl font-semibold">Actionable insights</h2>
+          <p className="mt-2 text-sm text-slate-600">
+            Track appointments, objections, and conversion rates in a single manager dashboard.
+            Export structured CSV data to sync with your CRM.
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@sales-call/web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.19",
+    "@types/react": "^18.2.48",
+    "@types/react-dom": "^18.2.18",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "14.1.0",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,59 @@
+# Architecture Overview
+
+This repository hosts the monorepo for the **Sales Call Recorder & AI Notes** platform. The goal of
+this first commit is to provide a structured foundation that reflects the product requirements and
+accelerates the next implementation steps.
+
+## Repository Layout
+
+```
+.
+├── apps/
+│   ├── api/     # NestJS backend (REST + WebSocket ready)
+│   └── web/     # Next.js frontend (App Router + Tailwind)
+├── docs/        # Product and architecture documentation
+├── package.json # npm workspaces configuration
+└── README.md
+```
+
+## Backend (NestJS)
+
+* `TypeORM` is preconfigured for PostgreSQL with entity stubs for `User`, `Call`, and `CallEvent`.
+* Service and controller scaffolding demonstrates the CRUD flows for calls and the audit trail.
+* Validation is enabled globally via `class-validator` and `class-transformer`.
+* TODO markers indicate where authentication/authorization and file handling should be wired in.
+
+### Next steps
+
+1. Implement authentication (JWT) and guard decorators for role-based access control.
+2. Add upload handling (S3/minio) for call audio and integrate BullMQ queues for ASR/NLP.
+3. Flesh out DTOs, pagination, filtering, and error handling to match the API contract.
+4. Define database migrations (using TypeORM migrations) and configure CI checks.
+
+## Frontend (Next.js)
+
+* Uses the App Router with TailwindCSS prewired.
+* Home page introduces the product value proposition and links to planned core pages.
+* Global layout + design tokens ensure a consistent look when additional pages arrive.
+
+### Next steps
+
+1. Build authentication pages (`/login`, `/register`) and wire them to the API.
+2. Implement the dashboard, call detail pages, and upload workflow.
+3. Connect to realtime updates via WebSocket once backend endpoints are available.
+4. Add component library primitives (buttons, inputs, tables) tailored to accessibility.
+
+## Tooling
+
+* npm workspaces keep the frontend and backend dependencies isolated while sharing commands.
+* `npm run dev:web` / `npm run dev:api` start each app in development mode.
+* `npm run build` composes both build commands for CI/CD pipelines.
+
+## Compliance Considerations
+
+The data model already reflects consent events and appointment tracking. Future iterations should
+ensure:
+
+* Consent prompts are enforced on the frontend and recorded via `CallEvent` entries.
+* Deletion flows cascade to S3 objects and transcripts.
+* Audit logs remain immutable to satisfy regulatory expectations.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "sales-call-recorder",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Monorepo for Sales Call Recorder & AI Notes application",
+  "license": "MIT",
+  "scripts": {
+    "dev:web": "npm --workspace=@sales-call/web run dev",
+    "dev:api": "npm --workspace=@sales-call/api run start:dev",
+    "build": "npm run build:web && npm run build:api",
+    "build:web": "npm --workspace=@sales-call/web run build",
+    "build:api": "npm --workspace=@sales-call/api run build"
+  },
+  "workspaces": [
+    "apps/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- set up npm workspaces with Next.js frontend and NestJS backend scaffolding
- add initial data models, services, and controllers that match the sales call domain
- document architecture decisions and update the README with onboarding details

## Testing
- not run (project scaffolding)

------
https://chatgpt.com/codex/tasks/task_e_68d683e65bb4832186a785d09453d485